### PR TITLE
Uncaught TypeError: Cannot read property 'length' of undefined

### DIFF
--- a/lib/markdown-table-formatter.coffee
+++ b/lib/markdown-table-formatter.coffee
@@ -74,7 +74,8 @@ class TableFormatter
         formatline = lines[1]
         formatrow = 1
         for line, i in lines
-            if !/\w/.exec(line)
+            # Add suport for analphabetic char
+            if !/(\w|[^\s\-\|\:])/.exec(line)
                 formatline = line
                 formatrow = i
                 # console.log(formatline)
@@ -82,7 +83,8 @@ class TableFormatter
                 break
 
         removeFormatRow = (s) ->
-             return /\w/.exec(s)
+             # Add suport for analphabetic char
+             return /(\w|[^\s\-\|\:])/.exec(s)
 
         lines = lines.filter(removeFormatRow)
         # console.log(lines)
@@ -92,12 +94,13 @@ class TableFormatter
         justify = []
         for cell in fstrings
             ends = cell[0] + (cell[cell.length-1] || '')
-            if ends == '::'
-                justify.push('::')
+            # Change default alignment to Center
+            if ends == ':-'
+                justify.push(':-')
             else if ends == '-:'
                 justify.push('-:')
             else
-                justify.push(':-')
+                justify.push('::')
 
         columns = justify.length
 


### PR DESCRIPTION
Hi,
I really like this creation, it's very helpful when I writing Markdown.But I find some problem, if a cell not contains alphabet,i mean some chinese characters,will get a error in Atom.So I changed some code, and it is worked in my Atom. 
However I am a newcomer of CofeeScript, if you have better way to fix this error I wait in hope for your update. `: )` 
- A little bug
When a cell contains only analphabetic characters will get error of
length:
> Uncaught TypeError: Cannot read property 'length' of undefined

- Change Default alignment to Centre
  It just personal property.