### PR TITLE
fix - minimum limit so last column still recognized

### DIFF
--- a/lib/table-formatter.coffee
+++ b/lib/table-formatter.coffee
@@ -145,7 +145,9 @@ class TableFormatter
         prewsum = sum(widths[...-1])
         widths[widths.length-1] = Math.max (@pll -
           prewsum -
-          widths.length - 1), 0
+          widths.length - 1), 3
+          # Need at least :-- for github to recognize a column
+        console.log widths
 
     just = (string, col) ->
       length = Math.max widths[col] - swidth(string), 0


### PR DESCRIPTION
Fixes a bug when "Limit Last Column Padding" is on and the column(s) prior to the last column are already very wide -- without the fix, it uses `:-` as the header for the last column, which [isn't big enough for GitHub to recognize it as a table](https://gist.github.com/mDuo13/b2b2f3d378bc0c2421f81983ffc4ef1a "Test Case").